### PR TITLE
Update readme with req puppet and concat versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 
 This module installs and configures the Gitlab CI Runner Package or nodes.
 
+## Installation Notes
+
+The 4.0 and greater releases of puppet-gitlab_ci_runner require Puppet 6 or newer, since it now uses the Deferred function. 
+
+Additionally, you must have puppetlabs-concat installed at version 6.3 or greater; earlier versions also do not support Deferred.
+
 ## Usage
 
 Here is an example how to configure Gitlab CI runners using Hiera:


### PR DESCRIPTION
Hey folks,

I ended up spinning my wheels for a bit trying to figure out why the module wouldn't work for us - it turns out you need to have puppetlabs-concat installed at 6.3 or greater in order for it to handle Deferred functions.  This PR adds a section to the readme noting that you need at least Puppet 6 and at least concat 6.3. Happy to modify as needed. Thanks.